### PR TITLE
Update Notification.js

### DIFF
--- a/src/Notification/widget/Notification.js
+++ b/src/Notification/widget/Notification.js
@@ -208,7 +208,7 @@ define([
         },
 
         _onClose: function (obj) {
-            if (this.mfOnClose !== "") {
+            if (this.mfOnClose !== "" && this._contextObj != null) {
                 mx.data.action({
                     params: {
                         applyto: 'selection',


### PR DESCRIPTION
Ran into an issue where when a user changes pages while the banner is still visible, it will throw an error on the on close event and then the banner will not close.

added an extra check for context object being null. 

